### PR TITLE
Enable retrobot to communicate in private channels

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,6 +198,17 @@ function isDM(message) {
   return message.channel[0] === 'D';
 }
 
+function getRetroParticipants(token, channel, callback) {
+  slack.channels.info({ token, channel }, (error, channelData) => {
+    if (channelData) return callback(null, channelData.channel.members || []);
+
+    slack.groups.info({ token, channel }, (groupError, groupData) => {
+      if (groupData) return callback(null, groupData.group.members || []);
+      return callback('Couldnt list members of this channel/group');
+    });
+  });
+}
+
 function command(message) {
   let [me, cmd, ...rest] = message.text.split(' ');
   cmd = cmd.toLowerCase().replace(/\W/g, '');
@@ -240,8 +251,11 @@ function command(message) {
     reply(message, msg);
     channel = message.channel;
     debug('getting list of members in %s', channel);
-    slack.channels.info({ token, channel }, (error, data) => {
-      let members = data.channel.members || [];
+    getRetroParticipants(token, channel, (error, members) => {
+      if (error) {
+        reply(message, 'Sorry, I failed to contact the participants of this retro... ' + error);
+      }
+
       members.filter(user => user !== bot.self.id).map(user => {
         // also check if the user is a) active, b) not DND
         slack.dnd.info({ token, user }, (error, dnd) => {


### PR DESCRIPTION
This PR enables retrobot to query active participants in both public channels and private groups. Fixes #1 
