### PR TITLE
Prevent multiple teams from interfering with one another

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,6 +162,9 @@ function handleMessage(message) {
 }
 
 function captureRetrospective(message) {
+  if (dms[message.user] !== message.channel) {
+    return reply(message, 'Another channel is currently running a retrospective and your invite got lost in the mail, sincerest appologies, retrobot xx')
+  }
   const line = message.text;
   const type = types[line[0]];
   if (message.edited || message.subtype === 'message_deleted') {
@@ -223,8 +226,10 @@ function command(message) {
   }
 
   if (aliases[cmd] === start) {
-    // TODO check and flush
-    inRetro = true;
+    if (inRetro) {
+      return reply(message, 'Another channel is currently using your friendly neighbourhood retrobot. Please try again later.');
+    }
+    inRetro = message.channel;
     reset();
 
     const autoend = rest.shift();
@@ -285,6 +290,9 @@ function command(message) {
 function stopRetro(message) {
   if (inRetro === false) {
     return reply(message, 'The retrospective finished already. I don\'t have a historical record of the retro to print here either. Sorry. Have some tea 🍵');
+  }
+  if (inRetro !== message.channel) {
+    return reply(message, 'Another channel is currently running a retrospective, you\'ll need to wait for them to finish.')
   }
   inRetro = false;
   reply(message, 'The retrospective has now finished, give me a second or ' +


### PR DESCRIPTION
This PR adds some sanity checks around who can interact with retrobot whilst a retrospective is in progress. I'm open to tweaking the response messages :wink: 
1. Prevent multiple channels from starting concurrent retrospectives.
2. Prevent users in different channels from interfering with someone elses retrospective (eg. prematurely stopping it)
3. Prevent users who are not in the active retrospective from contributing messages to an open retrospective.
