### PR TITLE
Fix for Cannot read property 'toLowerCase'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ function handleMessage(message) {
 
   if (isDM(message)) {
     debug('> got retrospective message: %s', message.text);
-    // capture the rerto data
+    // capture the retro data
     return captureRetrospective(message);
   } else if (isToBot(text)) {
     debug('> got potential command: %s', message.text);
@@ -166,6 +166,7 @@ function captureRetrospective(message) {
     return reply(message, 'Another channel is currently running a retrospective and your invite got lost in the mail, sincerest appologies, retrobot xx')
   }
   const line = message.text;
+  console.log(line);
   const type = types[line[0]];
   if (message.edited || message.subtype === 'message_deleted') {
     delete retrospective.plus[message.ts];
@@ -214,7 +215,9 @@ function getRetroParticipants(token, channel, callback) {
 
 function command(message) {
   let [me, cmd, ...rest] = message.text.split(' ');
-  cmd = cmd.toLowerCase().replace(/\W/g, '');
+  if (cmd){ // make sure there is something in cmd before doing .toLowerCase
+    cmd = cmd.toLowerCase().replace(/\W/g, '');
+  }
 
   debug('command: %s', cmd);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,7 +166,6 @@ function captureRetrospective(message) {
     return reply(message, 'Another channel is currently running a retrospective and your invite got lost in the mail, sincerest appologies, retrobot xx')
   }
   const line = message.text;
-  console.log(line);
   const type = types[line[0]];
   if (message.edited || message.subtype === 'message_deleted') {
     delete retrospective.plus[message.ts];


### PR DESCRIPTION
#6  Add a check to make sure there was a command entered.  If just `@botname` is used with no command provided i.e. `start` there was an attempt to change the user input to lowercase before processing the command.  if nothing was entered it was undefined resulting the error above