### PR TITLE
Add aynonomous option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ function handleMessage(message) {
 
   if (isDM(message)) {
     debug('> got retrospective message: %s', message.text);
-    // capture the rerto data
+    // capture the retro data
     return captureRetrospective(message);
   } else if (isToBot(text)) {
     debug('> got potential command: %s', message.text);
@@ -166,6 +166,7 @@ function captureRetrospective(message) {
     return reply(message, 'Another channel is currently running a retrospective and your invite got lost in the mail, sincerest appologies, retrobot xx')
   }
   const line = message.text;
+  console.log(line);
   const type = types[line[0]];
   if (message.edited || message.subtype === 'message_deleted') {
     delete retrospective.plus[message.ts];
@@ -214,7 +215,9 @@ function getRetroParticipants(token, channel, callback) {
 
 function command(message) {
   let [me, cmd, ...rest] = message.text.split(' ');
-  cmd = cmd.toLowerCase().replace(/\W/g, '');
+  if (cmd){ // make sure there is something in cmd before doing .toLowerCase
+    cmd = cmd.toLowerCase().replace(/\W/g, '');
+  }
 
   debug('command: %s', cmd);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const dict = require('./dict');
 const stop = 'stop';
 const start = 'start';
 const summary = 'summary';
+const aynonomous = 'aynonomous';
 const aliases = {
   stop,
   end: stop,
@@ -15,6 +16,9 @@ const aliases = {
   begin: start,
   summary,
   sum: summary,
+  aynonomous,
+  incognito: aynonomous,
+  hide: aynonomous,
   version: require('../package.json').version,
 };
 
@@ -28,6 +32,7 @@ const types = {
 let bot;
 const token = process.env.SLACK_TOKEN;
 let inRetro = false;
+let isAynonomous = false;
 let guid = 0;
 
 let dms = {};
@@ -182,6 +187,10 @@ function captureRetrospective(message) {
     return reply(message,
       `I've ignored \`${line}\` only because it didn't start with a \`+/-\``);
   }
+  
+  if (isAynonomous){
+    message.user = bot.self.id;
+  }
 
   retrospective[type][message.ts] = {
     user: message.user,
@@ -236,6 +245,22 @@ function command(message) {
     flushMessages(source, top);
 
     return;
+  }
+
+  if (cmd === aynonomous) {
+    if (isAynonomous){
+      isAynonomous = false;
+      return reply(message, ':male-detective: Aynonomous retrospective mode disabled');
+    }
+    else{
+      if(inRetro){
+        isAynonomous = true;
+        return reply(message, 'The remaining items for this retro will be taken and reported aynonomously.');
+      }
+      isAynonomous = true;
+      let msg = ':male-detective: Aynonomous retrospective mode enabled';
+      return reply(message, msg);
+    }
   }
 
   if (aliases[cmd] === start) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const dict = require('./dict');
 const stop = 'stop';
 const start = 'start';
 const summary = 'summary';
-const aynonomous = 'aynonomous';
+const anonymous = 'anonymous';
 const aliases = {
   stop,
   end: stop,
@@ -16,9 +16,9 @@ const aliases = {
   begin: start,
   summary,
   sum: summary,
-  aynonomous,
-  incognito: aynonomous,
-  hide: aynonomous,
+  anonymous,
+  incognito: anonymous,
+  hide: anonymous,
   version: require('../package.json').version,
 };
 
@@ -32,7 +32,7 @@ const types = {
 let bot;
 const token = process.env.SLACK_TOKEN;
 let inRetro = false;
-let isAynonomous = false;
+let isAnonymous = false;
 let guid = 0;
 
 let dms = {};
@@ -188,7 +188,7 @@ function captureRetrospective(message) {
       `I've ignored \`${line}\` only because it didn't start with a \`+/-\``);
   }
   
-  if (isAynonomous){
+  if (isAnonymous){
     message.user = bot.self.id;
   }
 
@@ -247,18 +247,18 @@ function command(message) {
     return;
   }
 
-  if (cmd === aynonomous) {
-    if (isAynonomous){
-      isAynonomous = false;
-      return reply(message, ':male-detective: Aynonomous retrospective mode disabled');
+  if (cmd === anonymous) {
+    if (isAnonymous){
+      isAnonymous = false;
+      return reply(message, ':male-detective: anonymous retrospective mode disabled');
     }
     else{
       if(inRetro){
-        isAynonomous = true;
-        return reply(message, 'The remaining items for this retro will be taken and reported aynonomously.');
+        isAnonymous = true;
+        return reply(message, 'The remaining items for this retro will be taken and reported anonymously.');
       }
-      isAynonomous = true;
-      let msg = ':male-detective: Aynonomous retrospective mode enabled';
+      isAnonymous = true;
+      let msg = ':male-detective: anonymous retrospective mode enabled';
       return reply(message, msg);
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,7 +166,6 @@ function captureRetrospective(message) {
     return reply(message, 'Another channel is currently running a retrospective and your invite got lost in the mail, sincerest appologies, retrobot xx')
   }
   const line = message.text;
-  console.log(line);
   const type = types[line[0]];
   if (message.edited || message.subtype === 'message_deleted') {
     delete retrospective.plus[message.ts];


### PR DESCRIPTION
#10 Could not replicate the duplicate items.

Created a new command `anonymous` which will toggle the ability to collect feedback anonymously.  If enabled prior to starting a retro, the feedback will be collected and scrubbed.  Toggle can be enabled / disabled at any time before, during or after a retro.  Feedback submitted while enabled will be scrubbed, otherwise will be credited to user who supplied the feedback.